### PR TITLE
动态扩展更多的结果码

### DIFF
--- a/server/app/common/BaseResultCode.js
+++ b/server/app/common/BaseResultCode.js
@@ -1,20 +1,29 @@
 class BaseResultCode {
-    //code
-    code;
-    //说明
-    desc;
-
-    constructor(code, desc) {//构造函数
+    constructor(code, desc) {
         this.code = code;
         this.desc = desc;
     }
 
-    /************************************/
-    static SUCCESS = new BaseResultCode(200, 'success');
-    static FAILED = new BaseResultCode(500, 'failed');
-    static VALIDATE_FAILED = new BaseResultCode(400, '参数校验失败');
-    static API_NOT_FOUNT = new BaseResultCode(404, '接口不存在');
-    static API_BUSY = new BaseResultCode(429, '操作过于频繁')
+    toString() {
+        return `Code: ${this.code}, Description: ${this.desc}`;
+    }
+
+    static codes = new Map();
+
+    static addCustomCode(key, code, desc) {
+        BaseResultCode.codes.set(key, new BaseResultCode(code, desc));
+    }
+
+    static getCodeByKey(key) {
+        return BaseResultCode.codes.get(key);
+    }
 }
 
-module.exports = BaseResultCode
+// 初始结果码定义
+BaseResultCode.addCustomCode('SUCCESS', 200, 'success');
+BaseResultCode.addCustomCode('FAILED', 500, 'failed');
+BaseResultCode.addCustomCode('VALIDATE_FAILED', 400, '参数校验失败');
+BaseResultCode.addCustomCode('API_NOT_FOUND', 404, '接口不存在');
+BaseResultCode.addCustomCode('API_BUSY', 429, '操作过于频繁');
+
+module.exports = BaseResultCode;

--- a/server/app/common/Result.js
+++ b/server/app/common/Result.js
@@ -1,63 +1,30 @@
-const ResultCode = require('./BaseResultCode');
-/**
- * @author byc
- * @description 统一返回结果
- */
-class Result {
-    /**
-     * 返回code
-     */
-    code;
-    /**
-     * 返回消息
-     */
-    msg;
-    /**
-     * 返回数据
-     */
-    data;
+const BaseResultCode = require('./BaseResultCode');
 
-    /**
-     * 
-     * @param code {number} 返回code
-     * @param msg {string} 返回消息
-     * @param data {any} 返回具体对象
-     */
+class Result {
     constructor(code, msg, data) {
         this.code = code;
         this.msg = msg;
         this.data = data;
     }
 
-    /**
-     * 成功
-     * @param data {any} 返回对象
-     * @return {Result}
-     */
     static success(data) {
-        return new Result(ResultCode.SUCCESS.code, ResultCode.SUCCESS.desc, data);
+        const successCode = BaseResultCode.getCodeByKey('SUCCESS');
+        return new Result(successCode.code, successCode.desc, data);
     }
 
-    /**
-     * 失败
-     */
     static fail(errData) {
-        return new Result(ResultCode.FAILED.code, ResultCode.FAILED.desc, errData);
+        const failCode = BaseResultCode.getCodeByKey('FAILED');
+        return new Result(failCode.code, failCode.desc, errData);
     }
 
-    /**
-     * 参数校验失败
-     */
     static validateFailed(param) {
-        return new Result(ResultCode.VALIDATE_FAILED.code, ResultCode.VALIDATE_FAILED.desc, param);
+        const validateFailedCode = BaseResultCode.getCodeByKey('VALIDATE_FAILED');
+        return new Result(validateFailedCode.code, validateFailedCode.desc, param);
     }
 
-    /**
-     * 拦截到的业务异常
-     * @param bizException {BizException} 业务异常
-     */
     static bizFail(bizException) {
         return new Result(bizException.code, bizException.msg, null);
     }
 }
-module.exports = Result
+
+module.exports = Result;


### PR DESCRIPTION
# 解决 #6 
## BaseResultCode 类更新

### 静态 Map 对象 `codes`
- **新增**：引入了一个静态 `Map` 对象 `codes`，用于存储所有的结果码。
- **目的**：提供一个集中的存储机制，方便管理和访问结果码。

### `addCustomCode` 方法
- **新增**：添加了 `addCustomCode` 方法。
- **功能**：允许开发者动态添加新的结果码到 `codes` Map 中。

### `getCodeByKey` 方法
- **新增**：添加了 `getCodeByKey` 方法。
- **功能**：允许通过键值从 `codes` Map 中获取结果码对象。

## Result 类更新

### 使用 `BaseResultCode.getCodeByKey` 方法
- **修改**：`Result` 类的静态方法（如 `success`、`fail`、`validateFailed` 和 `bizFail`）现在使用 `BaseResultCode.getCodeByKey` 方法获取静态结果码对象。
- **目的**：保持与 `BaseResultCode` 类的同步，确保结果码的一致性和准确性。


